### PR TITLE
Fix for lack of visualizations on Windows

### DIFF
--- a/src/resources/src/wgpu.zig
+++ b/src/resources/src/wgpu.zig
@@ -193,7 +193,7 @@ pub fn createRenderPipeline(
         .depth_stencil = &wgpu.DepthStencilState{
             .format = .depth32_float,
             .depth_write_enabled = true,
-            .depth_compare = .less,
+            .depth_compare = .less_equal,
         },
         .fragment = &wgpu.FragmentState{
             .module = fs_module,


### PR DESCRIPTION
On Windows only UI is visible. This small change makes the visualization visible (probably fixes also the same problem on macOS M1).