### PR TITLE
Make demos run with latest zig master and updated zig-gamedev libraries

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,26 +1,19 @@
-.{
-    .name = "Visual Simulations",
-    .version = "0.1.0",
-    .dependencies = .{
-        .dawn_x86_64_windows_gnu = .{
-            .url = "https://github.com/michal-z/webgpu_dawn-x86_64-windows-gnu/archive/d3a68014e6b6b53fd330a0ccba99e4dcfffddae5.tar.gz",
-            .hash = "1220f9448cde02ef3cd51bde2e0850d4489daa0541571d748154e89c6eb46c76a267",
-        },
-        .dawn_x86_64_linux_gnu = .{
-            .url = "https://github.com/michal-z/webgpu_dawn-x86_64-linux-gnu/archive/7d70db023bf254546024629cbec5ee6113e12a42.tar.gz",
-            .hash = "12204a3519efd49ea2d7cf63b544492a3a771d37eda320f86380813376801e4cfa73",
-        },
-        .dawn_aarch64_linux_gnu = .{
-            .url = "https://github.com/michal-z/webgpu_dawn-aarch64-linux-gnu/archive/c1f55e740a62f6942ff046e709ecd509a005dbeb.tar.gz",
-            .hash = "12205cd13f6849f94ef7688ee88c6b74c7918a5dfb514f8a403fcc2929a0aa342627",
-        },
-        .dawn_aarch64_macos = .{
-            .url = "https://github.com/michal-z/webgpu_dawn-aarch64-macos/archive/d2360cdfff0cf4a780cb77aa47c57aca03cc6dfe.tar.gz",
-            .hash = "12201fe677e9c7cfb8984a36446b329d5af23d03dc1e4f79a853399529e523a007fa"
-        },
-        .dawn_x86_64_macos = .{
-            .url = "https://github.com/michal-z/webgpu_dawn-x86_64-macos/archive/901716b10b31ce3e0d3fe479326b41e91d59c661.tar.gz",
-            .hash = "1220b1f02f2f7edd98a078c64e3100907d90311d94880a3cc5927e1ac009d002667a",
-        },
-     }
-}
+.{ .name = "Visual Simulations", .version = "0.1.0", .paths = .{""}, .dependencies = .{
+    .dawn_x86_64_windows_gnu = .{
+        .url = "https://github.com/michal-z/webgpu_dawn-x86_64-windows-gnu/archive/d3a68014e6b6b53fd330a0ccba99e4dcfffddae5.tar.gz",
+        .hash = "1220f9448cde02ef3cd51bde2e0850d4489daa0541571d748154e89c6eb46c76a267",
+    },
+    .dawn_x86_64_linux_gnu = .{
+        .url = "https://github.com/michal-z/webgpu_dawn-x86_64-linux-gnu/archive/7d70db023bf254546024629cbec5ee6113e12a42.tar.gz",
+        .hash = "12204a3519efd49ea2d7cf63b544492a3a771d37eda320f86380813376801e4cfa73",
+    },
+    .dawn_aarch64_linux_gnu = .{
+        .url = "https://github.com/michal-z/webgpu_dawn-aarch64-linux-gnu/archive/c1f55e740a62f6942ff046e709ecd509a005dbeb.tar.gz",
+        .hash = "12205cd13f6849f94ef7688ee88c6b74c7918a5dfb514f8a403fcc2929a0aa342627",
+    },
+    .dawn_aarch64_macos = .{ .url = "https://github.com/michal-z/webgpu_dawn-aarch64-macos/archive/d2360cdfff0cf4a780cb77aa47c57aca03cc6dfe.tar.gz", .hash = "12201fe677e9c7cfb8984a36446b329d5af23d03dc1e4f79a853399529e523a007fa" },
+    .dawn_x86_64_macos = .{
+        .url = "https://github.com/michal-z/webgpu_dawn-x86_64-macos/archive/901716b10b31ce3e0d3fe479326b41e91d59c661.tar.gz",
+        .hash = "1220b1f02f2f7edd98a078c64e3100907d90311d94880a3cc5927e1ac009d002667a",
+    },
+} }

--- a/libs/zglfw/build.zig
+++ b/libs/zglfw/build.zig
@@ -83,23 +83,26 @@ pub fn package(
             zglfw_c_cpp.linkSystemLibraryName("gdi32");
             zglfw_c_cpp.linkSystemLibraryName("user32");
             zglfw_c_cpp.linkSystemLibraryName("shell32");
-            zglfw_c_cpp.addCSourceFiles(&.{
-                src_dir ++ "monitor.c",
-                src_dir ++ "init.c",
-                src_dir ++ "vulkan.c",
-                src_dir ++ "input.c",
-                src_dir ++ "context.c",
-                src_dir ++ "window.c",
-                src_dir ++ "osmesa_context.c",
-                src_dir ++ "egl_context.c",
-                src_dir ++ "wgl_context.c",
-                src_dir ++ "win32_thread.c",
-                src_dir ++ "win32_init.c",
-                src_dir ++ "win32_monitor.c",
-                src_dir ++ "win32_time.c",
-                src_dir ++ "win32_joystick.c",
-                src_dir ++ "win32_window.c",
-            }, &.{"-D_GLFW_WIN32"});
+            zglfw_c_cpp.addCSourceFiles(.{
+                .files = &.{
+                    src_dir ++ "monitor.c",
+                    src_dir ++ "init.c",
+                    src_dir ++ "vulkan.c",
+                    src_dir ++ "input.c",
+                    src_dir ++ "context.c",
+                    src_dir ++ "window.c",
+                    src_dir ++ "osmesa_context.c",
+                    src_dir ++ "egl_context.c",
+                    src_dir ++ "wgl_context.c",
+                    src_dir ++ "win32_thread.c",
+                    src_dir ++ "win32_init.c",
+                    src_dir ++ "win32_monitor.c",
+                    src_dir ++ "win32_time.c",
+                    src_dir ++ "win32_joystick.c",
+                    src_dir ++ "win32_window.c",
+                },
+                .flags = &.{"-D_GLFW_WIN32"},
+            });
         },
         .macos => {
             zglfw_c_cpp.addFrameworkPath(
@@ -115,23 +118,26 @@ pub fn package(
             zglfw_c_cpp.linkFramework("CoreServices");
             zglfw_c_cpp.linkFramework("CoreGraphics");
             zglfw_c_cpp.linkFramework("Foundation");
-            zglfw_c_cpp.addCSourceFiles(&.{
-                src_dir ++ "monitor.c",
-                src_dir ++ "init.c",
-                src_dir ++ "vulkan.c",
-                src_dir ++ "input.c",
-                src_dir ++ "context.c",
-                src_dir ++ "window.c",
-                src_dir ++ "osmesa_context.c",
-                src_dir ++ "egl_context.c",
-                src_dir ++ "nsgl_context.m",
-                src_dir ++ "posix_thread.c",
-                src_dir ++ "cocoa_time.c",
-                src_dir ++ "cocoa_joystick.m",
-                src_dir ++ "cocoa_init.m",
-                src_dir ++ "cocoa_window.m",
-                src_dir ++ "cocoa_monitor.m",
-            }, &.{"-D_GLFW_COCOA"});
+            zglfw_c_cpp.addCSourceFiles(.{
+                .files = &.{
+                    src_dir ++ "monitor.c",
+                    src_dir ++ "init.c",
+                    src_dir ++ "vulkan.c",
+                    src_dir ++ "input.c",
+                    src_dir ++ "context.c",
+                    src_dir ++ "window.c",
+                    src_dir ++ "osmesa_context.c",
+                    src_dir ++ "egl_context.c",
+                    src_dir ++ "nsgl_context.m",
+                    src_dir ++ "posix_thread.c",
+                    src_dir ++ "cocoa_time.c",
+                    src_dir ++ "cocoa_joystick.m",
+                    src_dir ++ "cocoa_init.m",
+                    src_dir ++ "cocoa_window.m",
+                    src_dir ++ "cocoa_monitor.m",
+                },
+                .flags = &.{"-D_GLFW_COCOA"},
+            });
         },
         else => {
             // We assume Linux (X11)
@@ -142,24 +148,27 @@ pub fn package(
                 zglfw_c_cpp.addLibraryPath(.{ .path = thisDir() ++ "/../system-sdk/linux/lib/aarch64-linux-gnu" });
             }
             zglfw_c_cpp.linkSystemLibraryName("X11");
-            zglfw_c_cpp.addCSourceFiles(&.{
-                src_dir ++ "monitor.c",
-                src_dir ++ "init.c",
-                src_dir ++ "vulkan.c",
-                src_dir ++ "input.c",
-                src_dir ++ "context.c",
-                src_dir ++ "window.c",
-                src_dir ++ "osmesa_context.c",
-                src_dir ++ "egl_context.c",
-                src_dir ++ "glx_context.c",
-                src_dir ++ "posix_time.c",
-                src_dir ++ "posix_thread.c",
-                src_dir ++ "linux_joystick.c",
-                src_dir ++ "xkb_unicode.c",
-                src_dir ++ "x11_init.c",
-                src_dir ++ "x11_window.c",
-                src_dir ++ "x11_monitor.c",
-            }, &.{"-D_GLFW_X11"});
+            zglfw_c_cpp.addCSourceFiles(.{
+                .files = &.{
+                    src_dir ++ "monitor.c",
+                    src_dir ++ "init.c",
+                    src_dir ++ "vulkan.c",
+                    src_dir ++ "input.c",
+                    src_dir ++ "context.c",
+                    src_dir ++ "window.c",
+                    src_dir ++ "osmesa_context.c",
+                    src_dir ++ "egl_context.c",
+                    src_dir ++ "glx_context.c",
+                    src_dir ++ "posix_time.c",
+                    src_dir ++ "posix_thread.c",
+                    src_dir ++ "linux_joystick.c",
+                    src_dir ++ "xkb_unicode.c",
+                    src_dir ++ "x11_init.c",
+                    src_dir ++ "x11_window.c",
+                    src_dir ++ "x11_monitor.c",
+                },
+                .flags = &.{"-D_GLFW_X11"},
+            });
         },
     }
 

--- a/libs/zgpu/src/zgpu.zig
+++ b/libs/zgpu/src/zgpu.zig
@@ -1,4 +1,4 @@
-pub const version = @import("std").SemanticVersion{ .major = 0, .minor = 9, .patch = 0 };
+pub const version = @import("std").SemanticVersion{ .major = 0, .minor = 9, .patch = 1 };
 //--------------------------------------------------------------------------------------------------
 // zgpu is a small helper library built on top of native wgpu implementation (Dawn).
 //
@@ -55,7 +55,11 @@ pub const GraphicsContext = struct {
         } = .{},
     } = .{},
 
-    pub fn create(allocator: std.mem.Allocator, window: *zglfw.Window, options: GraphicsContextOptions) !*GraphicsContext {
+    pub fn create(
+        allocator: std.mem.Allocator,
+        window: *zglfw.Window,
+        options: GraphicsContextOptions,
+    ) !*GraphicsContext {
         const checkGraphicsApiSupport = (struct {
             fn impl() error{VulkanNotSupported}!void {
                 // TODO: On Windows we should check if DirectX 12 is supported (Windows 10+).

--- a/libs/zgui/build.zig
+++ b/libs/zgui/build.zig
@@ -85,37 +85,49 @@ pub fn package(
     });
 
     if (args.options.with_imgui) {
-        zgui_c_cpp.addCSourceFiles(&.{
-            thisDir() ++ "/libs/imgui/imgui.cpp",
-            thisDir() ++ "/libs/imgui/imgui_widgets.cpp",
-            thisDir() ++ "/libs/imgui/imgui_tables.cpp",
-            thisDir() ++ "/libs/imgui/imgui_draw.cpp",
-            thisDir() ++ "/libs/imgui/imgui_demo.cpp",
-        }, cflags);
+        zgui_c_cpp.addCSourceFiles(.{
+            .files = &.{
+                thisDir() ++ "/libs/imgui/imgui.cpp",
+                thisDir() ++ "/libs/imgui/imgui_widgets.cpp",
+                thisDir() ++ "/libs/imgui/imgui_tables.cpp",
+                thisDir() ++ "/libs/imgui/imgui_draw.cpp",
+                thisDir() ++ "/libs/imgui/imgui_demo.cpp",
+            },
+            .flags = cflags,
+        });
     }
 
     if (args.options.with_implot) {
-        zgui_c_cpp.addCSourceFiles(&.{
-            thisDir() ++ "/libs/imgui/implot_demo.cpp",
-            thisDir() ++ "/libs/imgui/implot.cpp",
-            thisDir() ++ "/libs/imgui/implot_items.cpp",
-        }, cflags);
+        zgui_c_cpp.addCSourceFiles(.{
+            .files = &.{
+                thisDir() ++ "/libs/imgui/implot_demo.cpp",
+                thisDir() ++ "/libs/imgui/implot.cpp",
+                thisDir() ++ "/libs/imgui/implot_items.cpp",
+            },
+            .flags = cflags,
+        });
     }
 
     switch (args.options.backend) {
         .glfw_wgpu => {
             zgui_c_cpp.addIncludePath(.{ .path = thisDir() ++ "/../zglfw/libs/glfw/include" });
             zgui_c_cpp.addIncludePath(.{ .path = thisDir() ++ "/../zgpu/libs/dawn/include" });
-            zgui_c_cpp.addCSourceFiles(&.{
-                thisDir() ++ "/libs/imgui/backends/imgui_impl_glfw.cpp",
-                thisDir() ++ "/libs/imgui/backends/imgui_impl_wgpu.cpp",
-            }, cflags);
+            zgui_c_cpp.addCSourceFiles(.{
+                .files = &.{
+                    thisDir() ++ "/libs/imgui/backends/imgui_impl_glfw.cpp",
+                    thisDir() ++ "/libs/imgui/backends/imgui_impl_wgpu.cpp",
+                },
+                .flags = cflags,
+            });
         },
         .win32_dx12 => {
-            zgui_c_cpp.addCSourceFiles(&.{
-                thisDir() ++ "/libs/imgui/backends/imgui_impl_win32.cpp",
-                thisDir() ++ "/libs/imgui/backends/imgui_impl_dx12.cpp",
-            }, cflags);
+            zgui_c_cpp.addCSourceFiles(.{
+                .files = &.{
+                    thisDir() ++ "/libs/imgui/backends/imgui_impl_win32.cpp",
+                    thisDir() ++ "/libs/imgui/backends/imgui_impl_dx12.cpp",
+                },
+                .flags = cflags,
+            });
             zgui_c_cpp.linkSystemLibraryName("d3dcompiler_47");
             zgui_c_cpp.linkSystemLibraryName("dwmapi");
         },

--- a/libs/zmath/README.md
+++ b/libs/zmath/README.md
@@ -27,7 +27,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
 
-    zmath_pkg = zmath.package(b, target, optimize, .{
+    const zmath_pkg = zmath.package(b, target, optimize, .{
         .options = .{ .enable_cross_platform_determinism = true },
     });
 

--- a/libs/zmath/src/zmath.zig
+++ b/libs/zmath/src/zmath.zig
@@ -527,7 +527,6 @@ pub inline fn isNearEqual(
     return temp <= epsilon;
 }
 test "zmath.isNearEqual" {
-    if (builtin.target.os.tag == .macos and builtin.zig_backend != .stage1) return error.SkipZigTest;
     {
         const v0 = f32x4(1.0, 2.0, -3.0, 4.001);
         const v1 = f32x4(1.0, 2.1, 3.0, 4.0);
@@ -556,7 +555,7 @@ test "zmath.isNearEqual" {
         splat(F32x4, 0.0001),
     ), 0) == false);
     try expect(all(isNearEqual(
-        splat(F32x4, -math.nan_f32),
+        splat(F32x4, -math.nan(f32)),
         splat(F32x4, math.inf(f32)),
         splat(F32x4, 0.0001),
     ), 0) == false);
@@ -569,12 +568,12 @@ pub inline fn isNan(
 }
 test "zmath.isNan" {
     {
-        const v0 = f32x4(math.inf(f32), math.nan_f32, math.nan_f32, 7.0);
+        const v0 = f32x4(math.inf(f32), math.nan(f32), math.nan(f32), 7.0);
         const b = isNan(v0);
         try expect(@reduce(.And, b == boolx4(false, true, true, false)));
     }
     {
-        const v0 = f32x8(0, math.nan_f32, 0, 0, math.inf(f32), math.nan_f32, math.qnan_f32, 7.0);
+        const v0 = f32x8(0, math.nan(f32), 0, 0, math.inf(f32), math.nan(f32), math.snan(f32), 7.0);
         const b = isNan(v0);
         try expect(@reduce(.And, b == boolx8(false, true, false, false, false, true, true, false)));
     }
@@ -588,12 +587,12 @@ pub inline fn isInf(
 }
 test "zmath.isInf" {
     {
-        const v0 = f32x4(math.inf(f32), math.nan_f32, math.qnan_f32, 7.0);
+        const v0 = f32x4(math.inf(f32), math.nan(f32), math.snan(f32), 7.0);
         const b = isInf(v0);
         try expect(@reduce(.And, b == boolx4(true, false, false, false)));
     }
     {
-        const v0 = f32x8(0, math.inf(f32), 0, 0, math.inf(f32), math.nan_f32, math.qnan_f32, 7.0);
+        const v0 = f32x8(0, math.inf(f32), 0, 0, math.inf(f32), math.nan(f32), math.snan(f32), 7.0);
         const b = isInf(v0);
         try expect(@reduce(.And, b == boolx8(false, true, false, false, true, false, false, false)));
     }
@@ -626,7 +625,7 @@ test "zmath.isInBounds" {
     }
     {
         const v0 = f32x8(2.0, 1.0, 2.0, 1.0, 0.5, -2.0, -1.0, 1.9);
-        const bounds = f32x8(1.0, 1.0, 1.0, math.inf(f32), 1.0, math.nan_f32, 1.0, 2.0);
+        const bounds = f32x8(1.0, 1.0, 1.0, math.inf(f32), 1.0, math.nan(f32), 1.0, 2.0);
         const b0 = isInBounds(v0, bounds);
         try expect(@reduce(.And, b0 == boolx8(false, true, false, true, true, false, true, true)));
     }
@@ -753,7 +752,7 @@ test "zmath.minFast" {
         try expect(approxEqAbs(v, f32x4(1.0, 1.0, 2.0, 7.0), 0.0));
     }
     {
-        const v0 = f32x4(1.0, math.nan_f32, 5.0, math.qnan_f32);
+        const v0 = f32x4(1.0, math.nan(f32), 5.0, math.snan(f32));
         const v1 = f32x4(2.0, 1.0, 4.0, math.inf(f32));
         const v = minFast(v0, v1);
         try expect(v[0] == 1.0);
@@ -776,7 +775,7 @@ test "zmath.maxFast" {
         try expect(approxEqAbs(v, f32x4(2.0, 3.0, 4.0, math.inf(f32)), 0.0));
     }
     {
-        const v0 = f32x4(1.0, math.nan_f32, 5.0, math.qnan_f32);
+        const v0 = f32x4(1.0, math.nan(f32), 5.0, math.snan(f32));
         const v1 = f32x4(2.0, 1.0, 4.0, math.inf(f32));
         const v = maxFast(v0, v1);
         try expect(v[0] == 2.0);
@@ -792,6 +791,7 @@ pub inline fn min(v0: anytype, v1: anytype) @TypeOf(v0, v1) {
     return @min(v0, v1); // minps, cmpunordps, andps, andnps, orps
 }
 test "zmath.min" {
+    // Calling math.inf causes test to fail!
     if (builtin.target.os.tag == .macos) return error.SkipZigTest;
     {
         const v0 = f32x4(1.0, 3.0, 2.0, 7.0);
@@ -806,7 +806,7 @@ test "zmath.min" {
         try expect(approxEqAbs(v, f32x8(0.0, 0.0, -2.0, 0.0, 1.0, 1.0, 2.0, 7.0), 0.0));
     }
     {
-        const v0 = f32x4(1.0, math.nan_f32, 5.0, math.qnan_f32);
+        const v0 = f32x4(1.0, math.nan(f32), 5.0, math.snan(f32));
         const v1 = f32x4(2.0, 1.0, 4.0, math.inf(f32));
         const v = min(v0, v1);
         try expect(v[0] == 1.0);
@@ -816,9 +816,10 @@ test "zmath.min" {
         try expect(v[3] == math.inf(f32));
         try expect(!math.isNan(v[3]));
     }
+
     {
-        const v0 = f32x4(-math.inf(f32), math.inf(f32), math.inf(f32), math.qnan_f32);
-        const v1 = f32x4(math.qnan_f32, -math.inf(f32), math.qnan_f32, math.nan_f32);
+        const v0 = f32x4(-math.inf(f32), math.inf(f32), math.inf(f32), math.snan(f32));
+        const v1 = f32x4(math.snan(f32), -math.inf(f32), math.snan(f32), math.nan(f32));
         const v = min(v0, v1);
         try expect(v[0] == -math.inf(f32));
         try expect(v[1] == -math.inf(f32));
@@ -834,6 +835,7 @@ pub inline fn max(v0: anytype, v1: anytype) @TypeOf(v0, v1) {
     return @max(v0, v1); // maxps, cmpunordps, andps, andnps, orps
 }
 test "zmath.max" {
+    // Calling math.inf causes test to fail!
     if (builtin.target.os.tag == .macos) return error.SkipZigTest;
     {
         const v0 = f32x4(1.0, 3.0, 2.0, 7.0);
@@ -848,7 +850,7 @@ test "zmath.max" {
         try expect(approxEqAbs(v, f32x8(0.0, 1.0, 0.0, 0.0, 2.0, 3.0, 4.0, math.inf(f32)), 0.0));
     }
     {
-        const v0 = f32x4(1.0, math.nan_f32, 5.0, math.qnan_f32);
+        const v0 = f32x4(1.0, math.nan(f32), 5.0, math.snan(f32));
         const v1 = f32x4(2.0, 1.0, 4.0, math.inf(f32));
         const v = max(v0, v1);
         try expect(v[0] == 2.0);
@@ -858,8 +860,8 @@ test "zmath.max" {
         try expect(!math.isNan(v[3]));
     }
     {
-        const v0 = f32x4(-math.inf(f32), math.inf(f32), math.inf(f32), math.qnan_f32);
-        const v1 = f32x4(math.qnan_f32, -math.inf(f32), math.qnan_f32, math.nan_f32);
+        const v0 = f32x4(-math.inf(f32), math.inf(f32), math.inf(f32), math.snan(f32));
+        const v1 = f32x4(math.snan(f32), -math.inf(f32), math.snan(f32), math.nan(f32));
         const v = max(v0, v1);
         try expect(v[0] == -math.inf(f32));
         try expect(v[1] == math.inf(f32));
@@ -916,10 +918,10 @@ test "zmath.round" {
     {
         try expect(all(round(splat(F32x4, math.inf(f32))) == splat(F32x4, math.inf(f32)), 0));
         try expect(all(round(splat(F32x4, -math.inf(f32))) == splat(F32x4, -math.inf(f32)), 0));
-        try expect(all(isNan(round(splat(F32x4, math.nan_f32))), 0));
-        try expect(all(isNan(round(splat(F32x4, -math.nan_f32))), 0));
-        try expect(all(isNan(round(splat(F32x4, math.qnan_f32))), 0));
-        try expect(all(isNan(round(splat(F32x4, -math.qnan_f32))), 0));
+        try expect(all(isNan(round(splat(F32x4, math.nan(f32)))), 0));
+        try expect(all(isNan(round(splat(F32x4, -math.nan(f32)))), 0));
+        try expect(all(isNan(round(splat(F32x4, math.snan(f32)))), 0));
+        try expect(all(isNan(round(splat(F32x4, -math.snan(f32)))), 0));
     }
     {
         var v = round(f32x16(1.1, -1.1, -1.5, 1.5, 2.1, 2.8, 2.9, 4.1, 5.8, 6.1, 7.9, 8.9, 10.1, 11.2, 12.7, 13.1));
@@ -937,7 +939,7 @@ test "zmath.round" {
     try expect(v[3] == math.inf(f32));
     try expect(approxEqAbs(v, f32x4(-10_000_000.1, -math.inf(f32), 10_000_001.5, math.inf(f32)), 0.0));
 
-    const v2 = f32x4(-math.qnan_f32, math.qnan_f32, math.nan_f32, -math.inf(f32));
+    const v2 = f32x4(-math.snan(f32), math.snan(f32), math.nan(f32), -math.inf(f32));
     v = round(v2);
     try expect(math.isNan(v2[0]));
     try expect(math.isNan(v2[1]));
@@ -1010,10 +1012,10 @@ test "zmath.trunc" {
     {
         try expect(all(trunc(splat(F32x4, math.inf(f32))) == splat(F32x4, math.inf(f32)), 0));
         try expect(all(trunc(splat(F32x4, -math.inf(f32))) == splat(F32x4, -math.inf(f32)), 0));
-        try expect(all(isNan(trunc(splat(F32x4, math.nan_f32))), 0));
-        try expect(all(isNan(trunc(splat(F32x4, -math.nan_f32))), 0));
-        try expect(all(isNan(trunc(splat(F32x4, math.qnan_f32))), 0));
-        try expect(all(isNan(trunc(splat(F32x4, -math.qnan_f32))), 0));
+        try expect(all(isNan(trunc(splat(F32x4, math.nan(f32)))), 0));
+        try expect(all(isNan(trunc(splat(F32x4, -math.nan(f32)))), 0));
+        try expect(all(isNan(trunc(splat(F32x4, math.snan(f32)))), 0));
+        try expect(all(isNan(trunc(splat(F32x4, -math.snan(f32)))), 0));
     }
     {
         var v = trunc(f32x16(1.1, -1.1, -1.5, 1.5, 2.1, 2.8, 2.9, 4.1, 5.8, 6.1, 7.9, 8.9, 10.1, 11.2, 12.7, 13.1));
@@ -1029,7 +1031,7 @@ test "zmath.trunc" {
     v = trunc(f32x4(-10_000_002.1, -math.inf(f32), 10_000_001.5, math.inf(f32)));
     try expect(approxEqAbs(v, f32x4(-10_000_002.1, -math.inf(f32), 10_000_001.5, math.inf(f32)), 0.0));
 
-    v = trunc(f32x4(-math.qnan_f32, math.qnan_f32, math.nan_f32, -math.inf(f32)));
+    v = trunc(f32x4(-math.snan(f32), math.snan(f32), math.nan(f32), -math.inf(f32)));
     try expect(math.isNan(v[0]));
     try expect(math.isNan(v[1]));
     try expect(math.isNan(v[2]));
@@ -1102,10 +1104,10 @@ test "zmath.floor" {
     {
         try expect(all(floor(splat(F32x4, math.inf(f32))) == splat(F32x4, math.inf(f32)), 0));
         try expect(all(floor(splat(F32x4, -math.inf(f32))) == splat(F32x4, -math.inf(f32)), 0));
-        try expect(all(isNan(floor(splat(F32x4, math.nan_f32))), 0));
-        try expect(all(isNan(floor(splat(F32x4, -math.nan_f32))), 0));
-        try expect(all(isNan(floor(splat(F32x4, math.qnan_f32))), 0));
-        try expect(all(isNan(floor(splat(F32x4, -math.qnan_f32))), 0));
+        try expect(all(isNan(floor(splat(F32x4, math.nan(f32)))), 0));
+        try expect(all(isNan(floor(splat(F32x4, -math.nan(f32)))), 0));
+        try expect(all(isNan(floor(splat(F32x4, math.snan(f32)))), 0));
+        try expect(all(isNan(floor(splat(F32x4, -math.snan(f32)))), 0));
     }
     {
         var v = floor(f32x16(1.1, -1.1, -1.5, 1.5, 2.1, 2.8, 2.9, 4.1, 5.8, 6.1, 7.9, 8.9, 10.1, 11.2, 12.7, 13.1));
@@ -1121,7 +1123,7 @@ test "zmath.floor" {
     v = floor(f32x4(-10_000_002.1, -math.inf(f32), 10_000_001.5, math.inf(f32)));
     try expect(approxEqAbs(v, f32x4(-10_000_002.1, -math.inf(f32), 10_000_001.5, math.inf(f32)), 0.0));
 
-    v = floor(f32x4(-math.qnan_f32, math.qnan_f32, math.nan_f32, -math.inf(f32)));
+    v = floor(f32x4(-math.snan(f32), math.snan(f32), math.nan(f32), -math.inf(f32)));
     try expect(math.isNan(v[0]));
     try expect(math.isNan(v[1]));
     try expect(math.isNan(v[2]));
@@ -1194,10 +1196,10 @@ test "zmath.ceil" {
     {
         try expect(all(ceil(splat(F32x4, math.inf(f32))) == splat(F32x4, math.inf(f32)), 0));
         try expect(all(ceil(splat(F32x4, -math.inf(f32))) == splat(F32x4, -math.inf(f32)), 0));
-        try expect(all(isNan(ceil(splat(F32x4, math.nan_f32))), 0));
-        try expect(all(isNan(ceil(splat(F32x4, -math.nan_f32))), 0));
-        try expect(all(isNan(ceil(splat(F32x4, math.qnan_f32))), 0));
-        try expect(all(isNan(ceil(splat(F32x4, -math.qnan_f32))), 0));
+        try expect(all(isNan(ceil(splat(F32x4, math.nan(f32)))), 0));
+        try expect(all(isNan(ceil(splat(F32x4, -math.nan(f32)))), 0));
+        try expect(all(isNan(ceil(splat(F32x4, math.snan(f32)))), 0));
+        try expect(all(isNan(ceil(splat(F32x4, -math.snan(f32)))), 0));
     }
     {
         var v = ceil(f32x16(1.1, -1.1, -1.5, 1.5, 2.1, 2.8, 2.9, 4.1, 5.8, 6.1, 7.9, 8.9, 10.1, 11.2, 12.7, 13.1));
@@ -1213,7 +1215,7 @@ test "zmath.ceil" {
     v = ceil(f32x4(-10_000_002.1, -math.inf(f32), 10_000_001.5, math.inf(f32)));
     try expect(approxEqAbs(v, f32x4(-10_000_002.1, -math.inf(f32), 10_000_001.5, math.inf(f32)), 0.0));
 
-    v = ceil(f32x4(-math.qnan_f32, math.qnan_f32, math.nan_f32, -math.inf(f32)));
+    v = ceil(f32x4(-math.snan(f32), math.snan(f32), math.nan(f32), -math.inf(f32)));
     try expect(math.isNan(v[0]));
     try expect(math.isNan(v[1]));
     try expect(math.isNan(v[2]));
@@ -1247,6 +1249,7 @@ pub inline fn clamp(v: anytype, vmin: anytype, vmax: anytype) @TypeOf(v, vmin, v
     return result;
 }
 test "zmath.clamp" {
+    // Calling math.inf causes test to fail!
     if (builtin.target.os.tag == .macos) return error.SkipZigTest;
     {
         const v0 = f32x4(-1.0, 0.2, 1.1, -0.3);
@@ -1259,12 +1262,12 @@ test "zmath.clamp" {
         try expect(approxEqAbs(v, f32x8(-0.5, 0.25, -0.25, 0.5, -0.5, 0.2, 0.5, -0.3), 0.0001));
     }
     {
-        const v0 = f32x4(-math.inf(f32), math.inf(f32), math.nan_f32, math.qnan_f32);
+        const v0 = f32x4(-math.inf(f32), math.inf(f32), math.nan(f32), math.snan(f32));
         const v = clamp(v0, f32x4(-100.0, 0.0, -100.0, 0.0), f32x4(0.0, 100.0, 0.0, 100.0));
         try expect(approxEqAbs(v, f32x4(-100.0, 100.0, -100.0, 0.0), 0.0001));
     }
     {
-        const v0 = f32x4(math.inf(f32), math.inf(f32), -math.nan_f32, -math.qnan_f32);
+        const v0 = f32x4(math.inf(f32), math.inf(f32), -math.nan(f32), -math.snan(f32));
         const v = clamp(v0, splat(F32x4, -1.0), splat(F32x4, 1.0));
         try expect(approxEqAbs(v, f32x4(1.0, 1.0, -1.0, -1.0), 0.0001));
     }
@@ -1290,6 +1293,7 @@ pub inline fn saturate(v: anytype) @TypeOf(v) {
     return result;
 }
 test "zmath.saturate" {
+    // Calling math.inf causes test to fail!
     if (builtin.target.os.tag == .macos) return error.SkipZigTest;
     {
         const v0 = f32x4(-1.0, 0.2, 1.1, -0.3);
@@ -1302,12 +1306,12 @@ test "zmath.saturate" {
         try expect(approxEqAbs(v, f32x8(0.0, 0.0, 1.0, 0.0, 0.0, 0.2, 1.0, 0.0), 0.0001));
     }
     {
-        const v0 = f32x4(-math.inf(f32), math.inf(f32), math.nan_f32, math.qnan_f32);
+        const v0 = f32x4(-math.inf(f32), math.inf(f32), math.nan(f32), math.snan(f32));
         const v = saturate(v0);
         try expect(approxEqAbs(v, f32x4(0.0, 1.0, 0.0, 0.0), 0.0001));
     }
     {
-        const v0 = f32x4(math.inf(f32), math.inf(f32), -math.nan_f32, -math.qnan_f32);
+        const v0 = f32x4(math.inf(f32), math.inf(f32), -math.nan(f32), -math.snan(f32));
         const v = saturate(v0);
         try expect(approxEqAbs(v, f32x4(1.0, 1.0, 0.0, 0.0), 0.0001));
     }
@@ -1331,12 +1335,12 @@ test "zmath.saturateFast" {
         try expect(approxEqAbs(v, f32x8(0.0, 0.0, 1.0, 0.0, 0.0, 0.2, 1.0, 0.0), 0.0001));
     }
     {
-        const v0 = f32x4(-math.inf(f32), math.inf(f32), math.nan_f32, math.qnan_f32);
+        const v0 = f32x4(-math.inf(f32), math.inf(f32), math.nan(f32), math.snan(f32));
         const v = saturateFast(v0);
         try expect(approxEqAbs(v, f32x4(0.0, 1.0, 0.0, 0.0), 0.0001));
     }
     {
-        const v0 = f32x4(math.inf(f32), math.inf(f32), -math.nan_f32, -math.qnan_f32);
+        const v0 = f32x4(math.inf(f32), math.inf(f32), -math.nan(f32), -math.snan(f32));
         const v = saturateFast(v0);
         try expect(approxEqAbs(v, f32x4(1.0, 1.0, 0.0, 0.0), 0.0001));
     }
@@ -1347,7 +1351,7 @@ pub inline fn sqrt(v: anytype) @TypeOf(v) {
 }
 
 pub inline fn abs(v: anytype) @TypeOf(v) {
-    return @fabs(v); // load, andps
+    return @abs(v); // load, andps
 }
 
 pub inline fn select(mask: anytype, v0: anytype, v1: anytype) @TypeOf(v0, v1) {
@@ -1435,21 +1439,20 @@ pub inline fn mod(v0: anytype, v1: anytype) @TypeOf(v0, v1) {
     return v0 - v1 * trunc(v0 / v1);
 }
 test "zmath.mod" {
-    if (builtin.target.os.tag == .macos and builtin.zig_backend != .stage1) return error.SkipZigTest;
     try expect(approxEqAbs(mod(splat(F32x4, 3.1), splat(F32x4, 1.7)), splat(F32x4, 1.4), 0.0005));
     try expect(approxEqAbs(mod(splat(F32x4, -3.0), splat(F32x4, 2.0)), splat(F32x4, -1.0), 0.0005));
     try expect(approxEqAbs(mod(splat(F32x4, -3.0), splat(F32x4, -2.0)), splat(F32x4, -1.0), 0.0005));
     try expect(approxEqAbs(mod(splat(F32x4, 3.0), splat(F32x4, -2.0)), splat(F32x4, 1.0), 0.0005));
     try expect(all(isNan(mod(splat(F32x4, math.inf(f32)), splat(F32x4, 1.0))), 0));
     try expect(all(isNan(mod(splat(F32x4, -math.inf(f32)), splat(F32x4, 123.456))), 0));
-    try expect(all(isNan(mod(splat(F32x4, math.nan_f32), splat(F32x4, 123.456))), 0));
-    try expect(all(isNan(mod(splat(F32x4, math.qnan_f32), splat(F32x4, 123.456))), 0));
-    try expect(all(isNan(mod(splat(F32x4, -math.qnan_f32), splat(F32x4, 123.456))), 0));
+    try expect(all(isNan(mod(splat(F32x4, math.nan(f32)), splat(F32x4, 123.456))), 0));
+    try expect(all(isNan(mod(splat(F32x4, math.snan(f32)), splat(F32x4, 123.456))), 0));
+    try expect(all(isNan(mod(splat(F32x4, -math.snan(f32)), splat(F32x4, 123.456))), 0));
     try expect(all(isNan(mod(splat(F32x4, 123.456), splat(F32x4, math.inf(f32)))), 0));
     try expect(all(isNan(mod(splat(F32x4, 123.456), splat(F32x4, -math.inf(f32)))), 0));
     try expect(all(isNan(mod(splat(F32x4, math.inf(f32)), splat(F32x4, math.inf(f32)))), 0));
-    try expect(all(isNan(mod(splat(F32x4, 123.456), splat(F32x4, math.nan_f32))), 0));
-    try expect(all(isNan(mod(splat(F32x4, math.inf(f32)), splat(F32x4, math.nan_f32))), 0));
+    try expect(all(isNan(mod(splat(F32x4, 123.456), splat(F32x4, math.nan(f32)))), 0));
+    try expect(all(isNan(mod(splat(F32x4, math.inf(f32)), splat(F32x4, math.nan(f32)))), 0));
 }
 
 pub fn modAngle(v: anytype) @TypeOf(v) {
@@ -1519,8 +1522,8 @@ test "zmath.sin" {
     try expect(approxEqAbs(sin(splat(F32x16, 89.123)), splat(F32x16, 0.916166), epsilon));
     try expect(all(isNan(sin(splat(F32x4, math.inf(f32)))), 0) == true);
     try expect(all(isNan(sin(splat(F32x4, -math.inf(f32)))), 0) == true);
-    try expect(all(isNan(sin(splat(F32x4, math.nan_f32))), 0) == true);
-    try expect(all(isNan(sin(splat(F32x4, math.qnan_f32))), 0) == true);
+    try expect(all(isNan(sin(splat(F32x4, math.nan(f32)))), 0) == true);
+    try expect(all(isNan(sin(splat(F32x4, math.snan(f32)))), 0) == true);
 
     var f: f32 = -100.0;
     var i: u32 = 0;
@@ -1567,8 +1570,8 @@ test "zmath.cos" {
     try expect(approxEqAbs(cos(splat(F32x4, -0.0)), splat(F32x4, 1.0), epsilon));
     try expect(all(isNan(cos(splat(F32x4, math.inf(f32)))), 0) == true);
     try expect(all(isNan(cos(splat(F32x4, -math.inf(f32)))), 0) == true);
-    try expect(all(isNan(cos(splat(F32x4, math.nan_f32))), 0) == true);
-    try expect(all(isNan(cos(splat(F32x4, math.qnan_f32))), 0) == true);
+    try expect(all(isNan(cos(splat(F32x4, math.nan(f32)))), 0) == true);
+    try expect(all(isNan(cos(splat(F32x4, math.snan(f32)))), 0) == true);
 
     var f: f32 = -100.0;
     var i: u32 = 0;
@@ -1780,8 +1783,8 @@ test "zmath.atan" {
     {
         try expect(approxEqAbs(atan(splat(F32x4, math.inf(f32))), splat(F32x4, 0.5 * math.pi), epsilon));
         try expect(approxEqAbs(atan(splat(F32x4, -math.inf(f32))), splat(F32x4, -0.5 * math.pi), epsilon));
-        try expect(all(isNan(atan(splat(F32x4, math.nan_f32))), 0) == true);
-        try expect(all(isNan(atan(splat(F32x4, -math.nan_f32))), 0) == true);
+        try expect(all(isNan(atan(splat(F32x4, math.nan(f32)))), 0) == true);
+        try expect(all(isNan(atan(splat(F32x4, -math.nan(f32)))), 0) == true);
     }
 }
 
@@ -1897,10 +1900,10 @@ test "zmath.atan2" {
     ));
     try expect(approxEqAbs(atan2(splat(F32x4, 0.0), splat(F32x4, 0.0)), splat(F32x4, 0.0), epsilon));
     try expect(approxEqAbs(atan2(splat(F32x4, -0.0), splat(F32x4, 0.0)), splat(F32x4, 0.0), epsilon));
-    try expect(all(isNan(atan2(splat(F32x4, 1.0), splat(F32x4, math.nan_f32))), 0) == true);
-    try expect(all(isNan(atan2(splat(F32x4, -1.0), splat(F32x4, math.nan_f32))), 0) == true);
-    try expect(all(isNan(atan2(splat(F32x4, math.nan_f32), splat(F32x4, -1.0))), 0) == true);
-    try expect(all(isNan(atan2(splat(F32x4, -math.nan_f32), splat(F32x4, 1.0))), 0) == true);
+    try expect(all(isNan(atan2(splat(F32x4, 1.0), splat(F32x4, math.nan(f32)))), 0) == true);
+    try expect(all(isNan(atan2(splat(F32x4, -1.0), splat(F32x4, math.nan(f32)))), 0) == true);
+    try expect(all(isNan(atan2(splat(F32x4, math.nan(f32)), splat(F32x4, -1.0))), 0) == true);
+    try expect(all(isNan(atan2(splat(F32x4, -math.nan(f32)), splat(F32x4, 1.0))), 0) == true);
 }
 // ------------------------------------------------------------------------------
 //
@@ -1996,13 +1999,12 @@ pub inline fn length4(v: Vec) F32x4 {
     return sqrt(dot4(v, v));
 }
 test "zmath.length3" {
-    if (builtin.target.os.tag == .macos and builtin.zig_backend != .stage1) return error.SkipZigTest;
     {
         const v = length3(f32x4(1.0, -2.0, 3.0, 1000.0));
         try expect(approxEqAbs(v, splat(F32x4, math.sqrt(14.0)), 0.001));
     }
     {
-        const v = length3(f32x4(1.0, math.nan_f32, math.nan_f32, 1000.0));
+        const v = length3(f32x4(1.0, math.nan(f32), math.nan(f32), 1000.0));
         try expect(all(isNan(v), 0));
     }
     {
@@ -2010,7 +2012,7 @@ test "zmath.length3" {
         try expect(all(isInf(v), 0));
     }
     {
-        const v = length3(f32x4(3.0, 2.0, 1.0, math.nan_f32));
+        const v = length3(f32x4(3.0, 2.0, 1.0, math.nan(f32)));
         try expect(approxEqAbs(v, splat(F32x4, math.sqrt(14.0)), 0.001));
     }
 }
@@ -2033,7 +2035,7 @@ test "zmath.normalize3" {
     {
         try expect(any(isNan(normalize3(f32x4(1.0, math.inf(f32), 1.0, 1.0))), 0));
         try expect(any(isNan(normalize3(f32x4(-math.inf(f32), math.inf(f32), 0.0, 0.0))), 0));
-        try expect(any(isNan(normalize3(f32x4(-math.nan_f32, math.qnan_f32, 0.0, 0.0))), 0));
+        try expect(any(isNan(normalize3(f32x4(-math.nan(f32), math.snan(f32), 0.0, 0.0))), 0));
         try expect(any(isNan(normalize3(f32x4(0, 0, 0, 0))), 0));
     }
 }
@@ -2046,7 +2048,7 @@ test "zmath.normalize4" {
     {
         try expect(any(isNan(normalize4(f32x4(1.0, math.inf(f32), 1.0, 1.0))), 0));
         try expect(any(isNan(normalize4(f32x4(-math.inf(f32), math.inf(f32), 0.0, 0.0))), 0));
-        try expect(any(isNan(normalize4(f32x4(-math.nan_f32, math.qnan_f32, 0.0, 0.0))), 0));
+        try expect(any(isNan(normalize4(f32x4(-math.nan(f32), math.snan(f32), 0.0, 0.0))), 0));
         try expect(any(isNan(normalize4(f32x4(0, 0, 0, 0))), 0));
     }
 }
@@ -3595,15 +3597,15 @@ test "zmath.sincos32" {
     try expect(math.isNan(sincos32(math.inf(f32))[1]));
     try expect(math.isNan(sincos32(-math.inf(f32))[0]));
     try expect(math.isNan(sincos32(-math.inf(f32))[1]));
-    try expect(math.isNan(sincos32(math.nan_f32)[0]));
-    try expect(math.isNan(sincos32(-math.nan_f32)[1]));
+    try expect(math.isNan(sincos32(math.nan(f32))[0]));
+    try expect(math.isNan(sincos32(-math.nan(f32))[1]));
 
     try expect(math.isNan(sin32(math.inf(f32))));
     try expect(math.isNan(cos32(math.inf(f32))));
     try expect(math.isNan(sin32(-math.inf(f32))));
     try expect(math.isNan(cos32(-math.inf(f32))));
-    try expect(math.isNan(sin32(math.nan_f32)));
-    try expect(math.isNan(cos32(-math.nan_f32)));
+    try expect(math.isNan(sin32(math.nan(f32))));
+    try expect(math.isNan(cos32(-math.nan(f32))));
 
     var f: f32 = -100.0;
     var i: u32 = 0;
@@ -3622,7 +3624,7 @@ test "zmath.sincos32" {
 }
 
 fn asin32(v: f32) f32 {
-    const x = @fabs(v);
+    const x = @abs(v);
     var omx = 1.0 - x;
     if (omx < 0.0) {
         omx = 0.0;
@@ -3649,15 +3651,15 @@ test "zmath.asin32" {
     try expect(math.approxEqAbs(f32, asin(@as(f32, 100000.1)), 0.5 * math.pi, epsilon));
     try expect(math.isNan(asin(math.inf(f32))));
     try expect(math.isNan(asin(-math.inf(f32))));
-    try expect(math.isNan(asin(math.nan_f32)));
-    try expect(math.isNan(asin(-math.nan_f32)));
+    try expect(math.isNan(asin(math.nan(f32))));
+    try expect(math.isNan(asin(-math.nan(f32))));
 
     try expect(approxEqAbs(asin(splat(F32x8, -100.0)), splat(F32x8, -0.5 * math.pi), epsilon));
     try expect(approxEqAbs(asin(splat(F32x16, 100.0)), splat(F32x16, 0.5 * math.pi), epsilon));
     try expect(all(isNan(asin(splat(F32x4, math.inf(f32)))), 0) == true);
     try expect(all(isNan(asin(splat(F32x4, -math.inf(f32)))), 0) == true);
-    try expect(all(isNan(asin(splat(F32x4, math.nan_f32))), 0) == true);
-    try expect(all(isNan(asin(splat(F32x4, math.qnan_f32))), 0) == true);
+    try expect(all(isNan(asin(splat(F32x4, math.nan(f32)))), 0) == true);
+    try expect(all(isNan(asin(splat(F32x4, math.snan(f32)))), 0) == true);
 
     var f: f32 = -1.0;
     var i: u32 = 0;
@@ -3676,7 +3678,7 @@ test "zmath.asin32" {
 }
 
 fn acos32(v: f32) f32 {
-    const x = @fabs(v);
+    const x = @abs(v);
     var omx = 1.0 - x;
     if (omx < 0.0) {
         omx = 0.0;
@@ -3703,15 +3705,15 @@ test "zmath.acos32" {
     try expect(math.approxEqAbs(f32, acos(@as(f32, 1000.1)), 0.0, epsilon));
     try expect(math.isNan(acos(math.inf(f32))));
     try expect(math.isNan(acos(-math.inf(f32))));
-    try expect(math.isNan(acos(math.nan_f32)));
-    try expect(math.isNan(acos(-math.nan_f32)));
+    try expect(math.isNan(acos(math.nan(f32))));
+    try expect(math.isNan(acos(-math.nan(f32))));
 
     try expect(approxEqAbs(acos(splat(F32x8, -100.0)), splat(F32x8, math.pi), epsilon));
     try expect(approxEqAbs(acos(splat(F32x16, 100.0)), splat(F32x16, 0.0), epsilon));
     try expect(all(isNan(acos(splat(F32x4, math.inf(f32)))), 0) == true);
     try expect(all(isNan(acos(splat(F32x4, -math.inf(f32)))), 0) == true);
-    try expect(all(isNan(acos(splat(F32x4, math.nan_f32))), 0) == true);
-    try expect(all(isNan(acos(splat(F32x4, math.qnan_f32))), 0) == true);
+    try expect(all(isNan(acos(splat(F32x4, math.nan(f32)))), 0) == true);
+    try expect(all(isNan(acos(splat(F32x4, math.snan(f32)))), 0) == true);
 
     var f: f32 = -1.0;
     var i: u32 = 0;
@@ -3731,7 +3733,7 @@ test "zmath.acos32" {
 
 pub fn modAngle32(in_angle: f32) f32 {
     const angle = in_angle + math.pi;
-    var temp: f32 = @fabs(angle);
+    var temp: f32 = @abs(angle);
     temp = temp - (2.0 * math.pi * @as(f32, @floatFromInt(@as(i32, @intFromFloat(temp / math.pi)))));
     temp = temp - math.pi;
     if (angle < 0.0) {
@@ -4495,7 +4497,7 @@ test "zmath.floatToIntAndBack" {
         try expect(approxEqAbs(v, f32x8(1.0, 2.0, 3.0, -4.0, 2.0, -2.0, 1.0, -100.0), 0.0));
     }
     {
-        const v = floatToIntAndBack(f32x4(math.inf(f32), 2.9, math.nan_f32, math.qnan_f32));
+        const v = floatToIntAndBack(f32x4(math.inf(f32), 2.9, math.nan(f32), math.snan(f32)));
         try expect(v[1] == 2.0);
     }
 }

--- a/src/signals/wave.zig
+++ b/src/signals/wave.zig
@@ -128,7 +128,7 @@ pub const Wave = struct {
                 break;
             }
             const secondX = second.xv.items[secondIdx];
-            const diff = @fabs(firstX - secondX);
+            const diff = @abs(firstX - secondX);
             if (diff < 0.001) {
                 const firstY = first.yv.items[firstIdx];
                 const secondY = second.yv.items[secondIdx];


### PR DESCRIPTION
Two small fixes are required to make demos build and run on latest zig master.
Zig-gamedev is already updated, so I also copied the latest libraries.